### PR TITLE
Update to checkpointing logic and embedding processing.

### DIFF
--- a/test_hierarchical.py
+++ b/test_hierarchical.py
@@ -1022,8 +1022,6 @@ def main():
                 # Training setup
                 best_val_accuracy = 0.0
                 best_epoch = 0
-                best_model_checkpoint_path = f"checkpoints/{config['description']}_best.pth"
-                os.makedirs(os.path.dirname(best_model_checkpoint_path), exist_ok=True)
                 
                 # Initialize I-value visualization tracking if enabled
                 viz_tracker = None
@@ -1034,9 +1032,13 @@ def main():
                     uses_ivalue_traversal = config['traversal'] in ['i-value', 'i-value-cluster-hop']
                 else:  # switching mode
                     uses_ivalue_traversal = any(t in ['i-value', 'i-value-cluster-hop'] for t in config.get('traversal_sequence', []))
-                # --- Use run-specific directory for all visualizations ---
+                # --- Use run-specific directory for all outputs ---
                 config_output_dir = run_output_dir / config['description']
                 config_output_dir.mkdir(parents=True, exist_ok=True)
+                # Checkpoints: save uniquely per run/config/DQN type to avoid collisions
+                ckpt_dir = config_output_dir / "checkpoints"
+                ckpt_dir.mkdir(parents=True, exist_ok=True)
+                best_model_checkpoint_path = str(ckpt_dir / f"{args.dqn_model}_best.pth")
                 
                 # Export node/edge CSVs with subcluster info if enabled
                 if getattr(args, 'export_csv_per_run', True):

--- a/trainers/capabilities/DQNCapability.py
+++ b/trainers/capabilities/DQNCapability.py
@@ -161,13 +161,28 @@ class DQNCapability:
                 print(f"Error converting features list to tensor: {e}. List: {features_list}")
                 features_tensor = None
 
-            # Handle embedding: convert to tensor or create zero tensor if missing/invalid
+            # Handle embedding: convert to tensor, then pad/truncate to expected dim
             embedding_tensor = None
             if embedding_data is not None:
                 try:
+                    # Convert and flatten if needed
                     embedding_tensor = torch.tensor(embedding_data, dtype=torch.float32)
+                    if embedding_tensor.ndim > 1:
+                        embedding_tensor = embedding_tensor.flatten()
+                    # Ensure fixed length equal to self.embedding_dim
+                    current_len = int(embedding_tensor.numel())
+                    target_len = int(self.embedding_dim)
+                    if target_len > 0 and current_len != target_len:
+                        if current_len > target_len:
+                            embedding_tensor = embedding_tensor[:target_len]
+                        else:
+                            pad_len = target_len - current_len
+                            embedding_tensor = torch.cat([
+                                embedding_tensor,
+                                torch.zeros(pad_len, dtype=torch.float32)
+                            ], dim=0)
                 except Exception as e:
-                    print(f"Error converting embedding to tensor: {e}. Using zeros.")
+                    print(f"Error converting/padding embedding to tensor: {e}. Using zeros of len {self.embedding_dim}.")
                     embedding_tensor = torch.zeros(self.embedding_dim, dtype=torch.float32)
 
             return features_tensor, embedding_tensor


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Scopes checkpoints to a run/config-specific directory and pads/truncates DQN embeddings to the expected dimension.
> 
> - **Training/experimentation (`test_hierarchical.py`)**:
>   - Route all outputs to a run-specific directory `run_outputs/<run_id>/<config>/`.
>   - Save checkpoints under `checkpoints/` with unique filenames per DQN type: `<dqn_model>_best.pth`.
> - **DQN capability (`trainers/capabilities/DQNCapability.py`)**:
>   - Normalize `face_embedding` tensors: flatten and pad/truncate to `self.embedding_dim`; improved error handling during conversion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6194fdd4c88f619c5f9157ccb0aef03e4ed007dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->