### PR TITLE
Device bugfixing

### DIFF
--- a/models/DQNModel.py
+++ b/models/DQNModel.py
@@ -44,15 +44,27 @@ class DQNModel(nn.Module):
         self.batch_size = 32
         self.gamma = 0.99
 
-    def _process_embedding(self, embedding):
-        """Processes the node embedding if the processor exists."""
+    def _process_embedding(self, embedding, batch_size=None):
+        """Processes the node embedding if the processor exists.
+        
+        Args:
+            embedding (torch.Tensor, optional): Tensor of node embeddings.
+            batch_size (int, optional): Batch size for creating zero tensors when embedding is None.
+        
+        Returns:
+            torch.Tensor or None: Processed embedding or None.
+        """
         if self.embedding_processor and embedding is not None:
             # Ensure embedding is on the correct device before processing
             embedding = embedding.to(self.device)
             return self.embedding_processor(embedding)
         elif self.embedding_dim > 0:
             # Return zeros if embedding is expected but None is provided
-            return torch.zeros(embedding.shape[0], self.compressed_embedding_dim, device=self.device)
+            if batch_size is None and embedding is not None:
+                batch_size = embedding.shape[0]
+            elif batch_size is None:
+                batch_size = 1  # Default to batch size of 1
+            return torch.zeros(batch_size, self.compressed_embedding_dim, device=self.device)
         else:
             # Return None if no embedding dimension is configured
             return None
@@ -70,7 +82,9 @@ class DQNModel(nn.Module):
         # Ensure features are on the correct device
         node_features = node_features.to(self.device)
         
-        processed_embedding = self._process_embedding(node_embedding)
+        # Get batch size from node_features
+        batch_size = node_features.shape[0] if node_features.dim() > 0 else 1
+        processed_embedding = self._process_embedding(node_embedding, batch_size=batch_size)
 
         if processed_embedding is not None:
             # Ensure processed_embedding is on the correct device

--- a/trainers/capabilities/DQNCapability.py
+++ b/trainers/capabilities/DQNCapability.py
@@ -177,9 +177,10 @@ class DQNCapability:
                             embedding_tensor = embedding_tensor[:target_len]
                         else:
                             pad_len = target_len - current_len
+                            # Ensure padding tensor is on the same device as embedding_tensor
                             embedding_tensor = torch.cat([
                                 embedding_tensor,
-                                torch.zeros(pad_len, dtype=torch.float32)
+                                torch.zeros(pad_len, dtype=torch.float32, device=embedding_tensor.device)
                             ], dim=0)
                 except Exception as e:
                     print(f"Error converting/padding embedding to tensor: {e}. Using zeros of len {self.embedding_dim}.")
@@ -223,16 +224,21 @@ class DQNCapability:
             else:
                 embedding_tensor = embedding_tensor.to(target_device)
 
-            # Features should already be a tensor
+            # Features should already be a tensor - ensure it's on the correct device
             features_tensor = features_tensor.to(target_device)
+
+            # Ensure DQN model is on the correct device (move all parameters)
+            if next(dqn_model.parameters()).device != target_device:
+                dqn_model = dqn_model.to(target_device)
+                # Update the reference in the list
+                self.dqns[model_idx] = dqn_model
 
             # Add batch dimension
             features_tensor = features_tensor.unsqueeze(0)
             embedding_tensor = embedding_tensor.unsqueeze(0)
 
-            # Get I-value from DQN
-            i_value = dqn_model.predict_i_value(features_tensor.to(dqn_model.device), 
-                                                embedding_tensor.to(dqn_model.device))
+            # Get I-value from DQN (predict_i_value will handle device placement internally)
+            i_value = dqn_model.predict_i_value(features_tensor, embedding_tensor)
 
             i_value = i_value.detach().cpu().item()
             


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves DQN robustness around embeddings and device placement.
> 
> - In `DQNModel`, `_process_embedding` now accepts `batch_size` and returns correctly sized zero embeddings when missing; `forward` derives batch size from `node_features` and handles device placement consistently
> - In `DQNCapability`, padding for embeddings uses tensors on the same device, features are moved to the DQN’s device, the DQN model is moved to the target device if mismatched, and `predict_i_value` is called without redundant device moves
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf191eb2cecc79e8193fcec687fe431b26c415b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->